### PR TITLE
Update return type

### DIFF
--- a/src/Concerns/ManagesAccount.php
+++ b/src/Concerns/ManagesAccount.php
@@ -84,9 +84,9 @@ trait ManagesAccount
     }
 
     /**
-     * @return int
+     * @return int|string
      */
-    public function getModelID(): int
+    public function getModelID(): int|string
     {
         return $this->{$this->primaryKey};
     }


### PR DESCRIPTION
The current return type is limited to `int`; a model using UUID or ULID returns a `string`, which will throw a `TypeError`.