### PR TITLE
Fix typo with `stripe_account_id` column name

### DIFF
--- a/database/migrations/2020_12_03_000001_create_connected_subscription_table.php
+++ b/database/migrations/2020_12_03_000001_create_connected_subscription_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
             $table->timestamp('ends_at')->nullable();
             $table->timestamps();
             $table->string('stripe_customer_id')->index();
-            $table->string('stripe_account_Id')->index()->nullable(); // FOR RELATING A CONNECTED CUSTOMER MODEL TO A CONNECTED ACCOUNT
+            $table->string('stripe_account_id')->index()->nullable(); // FOR RELATING A CONNECTED CUSTOMER MODEL TO A CONNECTED ACCOUNT
         });
     }
 


### PR DESCRIPTION
This PR fixes a bug where running

```php
public function createStripeCustomer(Store $store, Customer $customer){
    $stripeCustomer = $customer->createStripeCustomer($store, $customerData);
} 
```

fails because of a typo in the column name in `stripe_account_Id` (Capital `_Id` instead of just `_id`)