### PR TITLE
Jefhar/clarify execption messages

### DIFF
--- a/src/Concerns/ManagesAccount.php
+++ b/src/Concerns/ManagesAccount.php
@@ -100,7 +100,7 @@ trait ManagesAccount
     protected function assertAccountExists(): void
     {
         if (! $this->hasStripeAccount()) {
-            throw new AccountNotFoundException('Stripe account does not exist.');
+            throw new AccountNotFoundException('Stripe account does not exist for '.class_basename(static::class).' model');
         }
     }
 

--- a/src/Concerns/ManagesConnectSubscriptions.php
+++ b/src/Concerns/ManagesConnectSubscriptions.php
@@ -110,7 +110,7 @@ trait ManagesConnectSubscriptions
         $traits = class_uses($customer);
 
         if (!in_array('Lanos\CashierConnect\ConnectCustomer', $traits)) {
-            throw new Exception('The '.class_basename(static::class).' model does not have the connect ConnectCustomer trait.');
+            throw new Exception('The '.class_basename($customer).' model does not have the connect ConnectCustomer trait.');
         }
 
         $customer->assetCustomerExists();

--- a/src/Concerns/ManagesConnectSubscriptions.php
+++ b/src/Concerns/ManagesConnectSubscriptions.php
@@ -110,7 +110,7 @@ trait ManagesConnectSubscriptions
         $traits = class_uses($customer);
 
         if (!in_array('Lanos\CashierConnect\ConnectCustomer', $traits)) {
-            throw new Exception('This model does not have a connect ConnectCustomer trait on.');
+            throw new Exception('The '.class_basename(static::class).' model does not have the connect ConnectCustomer trait.');
         }
 
         $customer->assetCustomerExists();

--- a/src/ConnectCustomer.php
+++ b/src/ConnectCustomer.php
@@ -48,23 +48,23 @@ trait ConnectCustomer
             $traits = class_uses($connectedAccount);
 
             if(!in_array('Lanos\CashierConnect\Billable', $traits)){
-                throw new Exception('This model does not have a connect Billable trait on.');
+                throw new Exception('The '.class_basename(static::class).' model does not have the connect Billable trait.');
             }
 
             if ($connectedAccount->hasStripeAccount()) {
                 $options['stripe_account'] = $connectedAccount->stripeAccountId();
             }else{
-                throw new AccountNotFoundException('This model does not have a connect Billable trait on.');
+                throw new AccountNotFoundException('The '.class_basename(static::class).' model does not have the connect Billable trait.');
             }
         }
 
-        // Workaround for Cashier 12.x 
+        // Workaround for Cashier 12.x
         if (version_compare(Cashier::VERSION, '12.15.0', '<=')) {
             return array_merge(Cashier::stripeOptions($options));
         }
 
         $stripeOptions = Cashier::stripe($options);
-        
+
         return array_merge($options, [
             'api_key' => $stripeOptions->getApiKey()
         ]);

--- a/src/ConnectCustomer.php
+++ b/src/ConnectCustomer.php
@@ -54,7 +54,7 @@ trait ConnectCustomer
             if ($connectedAccount->hasStripeAccount()) {
                 $options['stripe_account'] = $connectedAccount->stripeAccountId();
             }else{
-                throw new AccountNotFoundException('The '.class_basename($connectedAccount).' model does not have the connect Billable trait.');
+                throw new AccountNotFoundException('The '.class_basename($connectedAccount).' model does not have a Stripe Account.');
             }
         }
 

--- a/src/ConnectCustomer.php
+++ b/src/ConnectCustomer.php
@@ -48,13 +48,13 @@ trait ConnectCustomer
             $traits = class_uses($connectedAccount);
 
             if(!in_array('Lanos\CashierConnect\Billable', $traits)){
-                throw new Exception('The '.class_basename(static::class).' model does not have the connect Billable trait.');
+                throw new Exception('The '.class_basename($connectedAccount).' model does not have the connect Billable trait.');
             }
 
             if ($connectedAccount->hasStripeAccount()) {
                 $options['stripe_account'] = $connectedAccount->stripeAccountId();
             }else{
-                throw new AccountNotFoundException('The '.class_basename(static::class).' model does not have the connect Billable trait.');
+                throw new AccountNotFoundException('The '.class_basename($connectedAccount).' model does not have the connect Billable trait.');
             }
         }
 


### PR DESCRIPTION
This PR clarifies three Exception messages, changing the ambiguous 'This' to a concrete class name.

It also includes whitespace fixes that my IDE automatically includes.