### PR TITLE
fix: could not retrieve host connected account

### DIFF
--- a/src/Concerns/ManageCustomer.php
+++ b/src/Concerns/ManageCustomer.php
@@ -95,9 +95,9 @@ trait ManageCustomer
 
         $model = $connectedAccount->model;
 
-        $model::find($this->getHostIDField($connectedAccount));
+        $modelId = $this->getHostIDField($connectedAccount);
 
-        return $model;
+        return $model::find($connectedAccount->$modelId);
 
     }
 


### PR DESCRIPTION
This will fix a bug where you could not delete a customer of a connected account via `->deleteStripeCustomer()`