### PR TITLE
Cashier 15 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 	Cashier For Connect
 </h1>
 
-# LARAVEL 10 + 11 SUPPORT COMING NEXT WEEK - + CASHIER AND STRIPE API LATEST VERSION
+## Cashier 15 Update Notes
+The Cashier 15 update brought about a few changes to the package. These include:
 
- ## Intro
+- Migrations no longer auto publish, you must now publish them using the command stated in the GitBook readme.
+  - Any use of ignoreMigrations() in your code can be and should be safely removed
+- Stripe API Version is now 2023-10-16, changes have been made to accommodate this
+
+## Intro
 
 This package is designed to seamlessly connect all of your eloquent models, mapping them to the relevant stripe entities in order to make a marketplace or payments platform.
 

--- a/composer.json
+++ b/composer.json
@@ -4,16 +4,17 @@
 	"keywords": ["laravel", "stripe", "stripe-connect", "billing"],
     "type": "library",
     "require": {
-        "laravel/cashier": "^12.6|^13.4|^v14.6.0",
-        "illuminate/console": "^8.37|^9.0|^10.0",
-        "illuminate/contracts": "^8.37|^9.0|^10.0",
-        "illuminate/database": "^8.37|^9.0|^10.0",
-        "illuminate/http": "^8.37|^9.0|^10.0",
-        "illuminate/log": "^8.37|^9.0|^10.0",
-        "illuminate/notifications": "^8.37|^9.0|^10.0",
-        "illuminate/routing": "^8.37|^9.0|^10.0",
-        "illuminate/support": "^8.37|^9.0|^10.0",
-        "illuminate/view": "^8.37|^9.0|^10.0"
+        "php" : "^7.2",
+        "laravel/cashier": "^12.6|^13.4|^v14.6.0|^v15.3.0",
+        "illuminate/console": "^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/database": "^9.0|^10.0|^11.0",
+        "illuminate/http": "^9.0|^10.0|^11.0",
+        "illuminate/log": "^9.0|^10.0|^11.0",
+        "illuminate/notifications": "^9.0|^10.0|^11.0",
+        "illuminate/routing": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/view": "^9.0|^10.0|^11.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"keywords": ["laravel", "stripe", "stripe-connect", "billing"],
     "type": "library",
     "require": {
-        "php" : "^7.2",
+        "php" : "^7.4|^8.1|^8.2|^8.3|^8.4",
         "laravel/cashier": "^12.6|^13.4|^v14.6.0|^v15.3.0",
         "illuminate/console": "^9.0|^10.0|^11.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0",

--- a/src/CashierConnectServiceProvider.php
+++ b/src/CashierConnectServiceProvider.php
@@ -21,7 +21,6 @@ class CashierConnectServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->initializeMigrations();
         $this->initializePublishing();
         $this->initializeCommands();
         $this->setupRoutes();
@@ -33,18 +32,6 @@ class CashierConnectServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/../config/cashierconnect.php', 'cashierconnect'
         );
-    }
-
-    /**
-     * Register the package migrations.
-     *
-     * @return void
-     */
-    protected function initializeMigrations()
-    {
-        if (Cashier::$runsMigrations && $this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        }
     }
 
     /**

--- a/src/Concerns/ManageCustomer.php
+++ b/src/Concerns/ManageCustomer.php
@@ -65,7 +65,7 @@ trait ManageCustomer
             throw new AccountAlreadyExistsException('Customer account already exists.');
         }
 
-        $customer = ConnectCustomer::create($customerData, $this->stripeAccountOptions($connectedAccount));
+        $customer = Customer::create($customerData, $this->stripeAccountOptions($connectedAccount));
 
         // Save the id.
         $this->stripeCustomerMapping()->create([

--- a/src/Concerns/ManageCustomer.php
+++ b/src/Concerns/ManageCustomer.php
@@ -65,7 +65,7 @@ trait ManageCustomer
             throw new AccountAlreadyExistsException('Customer account already exists.');
         }
 
-        $customer = Customer::create($customerData, $this->stripeAccountOptions($connectedAccount));
+        $customer = ConnectCustomer::create($customerData, $this->stripeAccountOptions($connectedAccount));
 
         // Save the id.
         $this->stripeCustomerMapping()->create([

--- a/src/Concerns/ManagesAccount.php
+++ b/src/Concerns/ManagesAccount.php
@@ -262,7 +262,7 @@ trait ManagesAccount
 
     private function getLocalIDField(){
 
-        if($this->incrementing){
+        if($this->getIncrementing()){
             return 'model_id';
         }else{
             return 'model_uuid';


### PR DESCRIPTION
This PR will address the version issues with laravel 10 and cashier 15.

- Fixed UUID connected accounts not creating properly
- Removed automatic publishing of migraitons in-line with Cashier 15's approach

I've tested this by doing the following:

Building out a basic boilerplate with Merchant and Customer models.

Then testing:

- Create connected account
- Create connected account customer
- Products
- Prices
- Create direct charge
- Create destination charge

They all seem to work fine.