### PR TITLE
Added stripe terminal support

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Lanos\CashierConnect;
-
 
 use Lanos\CashierConnect\Concerns\CanCharge;
 use Lanos\CashierConnect\Concerns\ManagesAccount;
@@ -14,6 +12,7 @@ use Lanos\CashierConnect\Concerns\ManagesConnectProducts;
 use Lanos\CashierConnect\Concerns\ManagesConnectSubscriptions;
 use Lanos\CashierConnect\Concerns\ManagesPerson;
 use Lanos\CashierConnect\Concerns\ManagesPayout;
+use Lanos\CashierConnect\Concerns\ManagesTerminals;
 use Lanos\CashierConnect\Concerns\ManagesTransfer;
 use Laravel\Cashier\Cashier;
 
@@ -36,7 +35,7 @@ trait Billable
     use CanCharge;
     use ManagesPayout;
     use ManagesApplePayDomain;
-
+    use ManagesTerminals;
 
     /**
      * The default Stripe API options for the current Billable model.
@@ -65,6 +64,10 @@ trait Billable
         ]);
     }
 
+    /**
+     * @param $providedCurrency
+     * @return mixed|string
+     */
     public function establishTransferCurrency($providedCurrency = null){
 
         if($providedCurrency){

--- a/src/Concerns/CanCharge.php
+++ b/src/Concerns/CanCharge.php
@@ -53,6 +53,15 @@ trait CanCharge
 
     }
 
+    /**
+     * @param int $amount
+     * @param string|null $currencyToUse
+     * @param array $options
+     * @param bool $onBehalfOf
+     * @return PaymentIntent
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
     public function createDestinationCharge(int $amount, string $currencyToUse = null, array $options = [], bool $onBehalfOf = false): PaymentIntent
     {
 
@@ -85,7 +94,11 @@ trait CanCharge
     }
 
 
-
+    /**
+     * @param $amount
+     * @return float|int
+     * @throws \Exception
+     */
     private function calculatePercentageFee($amount){
         if($this->commission_rate < 100){
             return ($this->commission_rate / 100) * $amount;

--- a/src/Concerns/ManagesAccount.php
+++ b/src/Concerns/ManagesAccount.php
@@ -42,7 +42,7 @@ trait ManagesAccount
             ];
         }
 
-        $mapping = $this->stripeAccountMapping()->update([
+        $this->stripeAccountMapping()->update([
             "future_requirements" => $account->future_requirements->toArray(),
             "requirements" => $account->requirements->toArray(),
             "charges_enabled" => $account->charges_enabled
@@ -260,6 +260,9 @@ trait ManagesAccount
         return $accountUpdate;
     }
 
+    /**
+     * @return string
+     */
     private function getLocalIDField(){
 
         if($this->incrementing){

--- a/src/Concerns/ManagesApplePayDomain.php
+++ b/src/Concerns/ManagesApplePayDomain.php
@@ -8,6 +8,7 @@ use Lanos\CashierConnect\Exceptions\AccountNotFoundException;
 use Lanos\CashierConnect\Models\ConnectMapping;
 use Stripe\Account;
 use Stripe\ApplePayDomain;
+use Stripe\Collection;
 use Stripe\Exception\ApiErrorException;
 
 /**
@@ -18,12 +19,23 @@ use Stripe\Exception\ApiErrorException;
 trait ManagesApplePayDomain
 {
 
+    /**
+     * @param $domain
+     * @return ApplePayDomain
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
     public function addApplePayDomain($domain){
         $this->assertAccountExists();
         return ApplePayDomain::create(['domain_name' => $domain], $this->stripeAccountOptions([], true));
 
     }
 
+    /**
+     * @return Collection
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
     public function getApplePayDomains(){
         $this->assertAccountExists();
         return ApplePayDomain::all([], $this->stripeAccountOptions([], true));

--- a/src/Concerns/ManagesConnectSubscriptions.php
+++ b/src/Concerns/ManagesConnectSubscriptions.php
@@ -80,6 +80,9 @@ trait ManagesConnectSubscriptions
 
     }
 
+    /**
+     * @return mixed
+     */
     public function getSubscriptions(){
         return $this->stripeAccountMapping->subscriptions;
     }
@@ -95,6 +98,11 @@ trait ManagesConnectSubscriptions
         return Subscription::retrieve($id, $this->stripeAccountOptions([], true));
     }
 
+    /**
+     * @param $customer
+     * @return mixed
+     * @throws Exception
+     */
     private function determineCustomerInput($customer)
     {
         if (gettype($customer) === 'string') {
@@ -104,6 +112,11 @@ trait ManagesConnectSubscriptions
         }
     }
 
+    /**
+     * @param $customer
+     * @return mixed
+     * @throws Exception
+     */
     private function handleConnectedCustomer($customer)
     {
         // IT IS A CUSTOMER TRAIT MODEL

--- a/src/Concerns/ManagesTerminals.php
+++ b/src/Concerns/ManagesTerminals.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Lanos\CashierConnect\Concerns;
+
+use Lanos\CashierConnect\Exceptions\AccountNotFoundException;
+use Stripe\Collection;
+use Stripe\Exception\ApiErrorException;
+use Stripe\Terminal\ConnectionToken;
+use Stripe\Terminal\Location;
+use Stripe\Terminal\Reader;
+
+/**
+ * Manages terminals and locations for the connected account
+ *
+ * @package Lanos\CashierConnect\Concerns
+ */
+trait ManagesTerminals
+{
+
+    /**
+     * @param $data
+     * @return Location
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
+    public function addTerminalLocation($data){
+        $this->assertAccountExists();
+        return Location::create($data, $this->stripeAccountOptions([], true));
+    }
+
+    /**
+     * @return Collection
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
+    public function getTerminalLocations(){
+        $this->assertAccountExists();
+        return Location::all([], $this->stripeAccountOptions([], true));
+    }
+
+    /**
+     * @param $data
+     * @return Reader
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
+    public function registerTerminalReader($data){
+        $this->assertAccountExists();
+        return Reader::create($data, $this->stripeAccountOptions([], true));
+    }
+
+    /**
+     * @return Collection
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
+    public function getTerminalReaders(){
+        $this->assertAccountExists();
+        return Reader::all([], $this->stripeAccountOptions([], true));
+    }
+
+    /**
+     * @param $location
+     * @return ConnectionToken
+     * @throws AccountNotFoundException
+     * @throws ApiErrorException
+     */
+    public function createConnectionToken($location){
+        $this->assertAccountExists();
+        return ConnectionToken::create([
+            "location" => $location
+        ], $this->stripeAccountOptions([], true));
+    }
+
+}


### PR DESCRIPTION
Added in stripe terminal support for connected accounts.

This covers:

- Registering locations for the terminals
- Registering the readers and assocaiting them to locations
- Handling connection tokens for terminal sessions.