### PR TITLE
Add Laravel 11 migrations publishing logic

### DIFF
--- a/src/CashierConnectServiceProvider.php
+++ b/src/CashierConnectServiceProvider.php
@@ -42,10 +42,15 @@ class CashierConnectServiceProvider extends ServiceProvider
     protected function initializePublishing()
     {
         if ($this->app->runningInConsole()) {
-            $this->publishes([
+
+            $publishesMigrationsMethod = method_exists($this, 'publishesMigrations')
+                ? 'publishesMigrations'
+                : 'publishes';
+
+            $this->{$publishesMigrationsMethod}([
                 __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
             ], 'cashier-connect-migrations');
-            $this->publishes([
+            $this->{$publishesMigrationsMethod}([
                 __DIR__.'/../database/migrations' => $this->app->databasePath('migrations/tenant'),
             ], 'cashier-connect-tenancy-migrations');
         }


### PR DESCRIPTION
These changes, taken from `Laravel\Cashier` package, are needed to update migrations timestamp when publishing.