### PR TITLE
Add support for Laravel Cashier 16.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.3.0] - 2025-11-18
+
+### Added
+- Support for Laravel Cashier 16.x
+- New columns in `connected_subscription_items` table:
+  - `meter_event_name` (nullable) - For metered billing support
+  - `meter_id` (nullable) - For metered billing support
+- Compatibility with Stripe API version `2025-07-30.basil`
+- `UPGRADE.md` file with detailed upgrade instructions
+
+### Changed
+- Updated `laravel/cashier` version constraint to include `^16.0`
+- Added `meter_id` cast as `string` in `ConnectSubscriptionItem` model
+
+## [1.2.3]
+
+### Added
+- Payment Links functionality for connected accounts
+- Creation of both Direct and Destination payment links, including "on behalf of" support
+- Support for percentage and fixed application fees on payment links
+- Retrieval of all direct payment links for a connected account
+
+## [1.2.2]
+
+### Added
+- Functionality for physical terminals and Apple/Android tap to pay
+- Adding terminal locations
+- Adding a reader and associating it with a terminal
+- Handling connection token requests
+
+## [1.1.0]
+
+### Changed
+- Compatibility with Cashier 15
+- Migrations are no longer auto-published, must now be published using the `vendor:publish` command
+- Updated to Stripe API version 2023-10-16
+
+### Removed
+- Support for `ignoreMigrations()` - can be safely removed from code
+
+## Earlier Versions
+
+See Git history for changes in versions prior to 1.1.0.
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ Working on open source packages and helping other developers is my true passion,
 
 ### Documentation has been updated to cover the new features introduced in 1.2.2.
 
+## V1.3.0 Update (Cashier 16)
+This update brings compatibility with Laravel Cashier 16.x which introduces support for Stripe's new metered billing API (Stripe Billing Meters). Changes include:
+
+- Support for Laravel Cashier ^16.0
+- Added new columns to the `connected_subscription_items` table: `meter_event_name` and `meter_id`
+- Compatibility with Stripe API version `2025-07-30.basil`
+
+To upgrade, run:
+```bash
+composer update
+php artisan vendor:publish --tag="cashier-connect-migrations"
+php artisan migrate
+```
+
+**Important Note:** After deploying this update, remember to update your Stripe API version in your Stripe dashboard to `2025-07-30.basil` to take full advantage of the new features.
+
 ## V1.2.3 Update
 This update bring new functionality for users wishing to use payment links with their connected accounts:
 - Create both Direct and Destination payment links, including using "on behalf of".

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,65 @@
+# Upgrade Guide
+
+## Upgrading to 1.3.0 (Cashier 16.x)
+
+### Major Changes
+
+Laravel Cashier Stripe Connect 1.3.0 introduces compatibility with Laravel Cashier 16.x, which brings support for Stripe's new metered billing APIs (Stripe Billing Meters).
+
+### Upgrade Steps
+
+#### 1. Update Your Dependencies
+
+Update your `composer.json` file:
+
+```bash
+composer update
+```
+
+#### 2. Publish and Run Migrations
+
+Two new columns have been added to the `connected_subscription_items` table:
+- `meter_event_name` (nullable) - The meter event name for metered billing
+- `meter_id` (nullable) - The Stripe meter identifier
+
+Publish the new migrations:
+
+```bash
+php artisan vendor:publish --tag="cashier-connect-migrations" --force
+```
+
+Run the migrations:
+
+```bash
+php artisan migrate
+```
+
+#### 3. Update Your Stripe API Version
+
+After deploying this update to production, log in to your Stripe dashboard and update your API version to `2025-07-30.basil` to take full advantage of the new features.
+
+**Important:** Test in a staging environment first. Older Stripe accounts may encounter compatibility issues with the new Basil APIs or require manual API key upgrades.
+
+### Database Changes
+
+The `connected_subscription_items` table now has two new columns:
+
+| Column | Type | Description |
+|---------|------|-------------|
+| `meter_event_name` | string (nullable) | Event name for metered billing |
+| `meter_id` | string (nullable) | Stripe meter ID |
+
+### Compatibility
+
+- Laravel Cashier: ^16.0
+- Stripe API: 2025-07-30.basil
+- PHP: ^7.4\|^8.1\|^8.2\|^8.3\|^8.4
+- Laravel: ^9.0\|^10.0\|^11.0\|^12.0
+
+### Notes
+
+- Changes primarily concern metered billing
+- If you don't use metered billing, the new columns will remain NULL
+- Backward compatibility with previous Cashier versions (12.x, 13.x, 14.x, 15.x) is maintained
+- No existing code modifications are required if you don't use metered billing
+

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "require": {
         "php" : "^7.4|^8.1|^8.2|^8.3|^8.4",
-        "laravel/cashier": "^12.6|^13.4|^v14.6.0|^v15.3.0",
+        "laravel/cashier": "^12.6|^13.4|^v14.6.0|^v15.3.0|^16.0",
         "illuminate/console": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/database": "^9.0|^10.0|^11.0|^12.0",

--- a/database/migrations/2025_11_18_000001_add_meter_columns_to_connected_subscription_items.php
+++ b/database/migrations/2025_11_18_000001_add_meter_columns_to_connected_subscription_items.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds meter columns for Cashier 16.x metered billing support.
+ */
+return new class extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('connected_subscription_items', function (Blueprint $table) {
+            $table->string('meter_event_name')->nullable()->after('quantity');
+            $table->string('meter_id')->nullable()->after('meter_event_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('connected_subscription_items', function (Blueprint $table) {
+            $table->dropColumn(['meter_event_name', 'meter_id']);
+        });
+    }
+};

--- a/src/Models/ConnectSubscriptionItem.php
+++ b/src/Models/ConnectSubscriptionItem.php
@@ -10,8 +10,17 @@ class ConnectSubscriptionItem extends Model
     protected $guarded = [];
     protected $table = 'connected_subscription_items';
 
-    public function subscription(){
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'meter_id' => 'string',
+    ];
+
+    public function subscription()
+    {
         return $this->belongsTo(ConnectSubscription::class, 'connected_subscription_id', 'id');
     }
-
 }


### PR DESCRIPTION
## Description
This PR adds support for Laravel Cashier 16.x, which introduces Stripe's new metered billing API (Stripe Billing Meters).

## Changes
- Add support for Laravel Cashier ^16.0
- Add new migration with `meter_event_name` and `meter_id` columns
- Update `ConnectSubscriptionItem` model with proper casting
- Add comprehensive `UPGRADE.md` guide
- Add `CHANGELOG.md` for version tracking
- Update README with v1.3.0 release notes

## Compatibility
- Maintains backward compatibility with Cashier 12.x-15.x
- Compatible with Stripe API version 2025-07-30.basil
- Tested with PHP 7.4-8.4 and Laravel 9-12

## Notes
- Changes primarily concern metered billing functionality
- New columns are nullable and won't affect existing installations
- No breaking changes